### PR TITLE
Option to use custom bug fix pattern

### DIFF
--- a/gitrisky/cli.py
+++ b/gitrisky/cli.py
@@ -14,7 +14,9 @@ def cli():
 
 
 @cli.command()
-def train():
+@click.option('-p', '--pattern', required=False,
+              help="Bug fix pattern. Ex. BUG,FIX", type=str)
+def train(pattern=None):
     """Train a git commit bug risk model.
 
     This will save a pickled sklearn model to a file in the toplevel directory
@@ -23,7 +25,10 @@ def train():
 
     # get the features and labels by parsing the git logs
     features = get_features()
-    labels = get_labels()
+    if pattern is not None:
+        labels = get_labels(pattern.split(','))
+    else:
+        labels = get_labels(pattern)
 
     # instantiate and train a model
     model = create_model()

--- a/gitrisky/parsing.py
+++ b/gitrisky/parsing.py
@@ -135,7 +135,7 @@ def get_features(commit=None):
     return feats
 
 
-def get_labels():
+def get_labels(pattern=None):
     """Get a label for each commit indicating whether it introduced a bug.
 
     Returns
@@ -147,7 +147,7 @@ def get_labels():
 
     feats = get_features()
 
-    fix_commits = get_bugfix_commits()
+    fix_commits = get_bugfix_commits(pattern)
 
     bug_commits = link_fixes_to_bugs(fix_commits)
 


### PR DESCRIPTION
In cases when you don't use `BUG` and `FIX` to mark your bug fixes, you need to change it using `--pattern` or `-p`.

**Example:**

    $ gitrisky train -p БАГ,ФИКС

_P.S. БАГ is BUG in Russian._
Pretty self-explanatory.
Edit 1:
Also `_run_bash_command` now exits with error code 1 when `bash_cmd` exits with other error code then 0.